### PR TITLE
feat: support className prop when using css prop

### DIFF
--- a/src/ts-transformer/css-prop/__tests__/index.test.tsx
+++ b/src/ts-transformer/css-prop/__tests__/index.test.tsx
@@ -60,9 +60,31 @@ describe('css prop transformer', () => {
     expect(actual).toIncludeRepeated('import React, { useState } from "react"', 1);
   });
 
-  it.todo('should concat explicit use of class name prop on an element');
+  it('should concat explicit use of class name prop on an element', () => {
+    const actual = transformer.transform(`
+      /** @jsx jsx */
+      import { jsx } from '${pkg.name}';
+
+      <div className="foobar" css={{}}>hello world</div>
+    `);
+
+    expect(actual).toInclude('className={"test-class" + " " + "foobar"}');
+  });
 
   it.todo('should concat implicit use of class name prop where props are spread into an element');
+
+  it('should concat implicit use of class name prop where class name is a jsx expression', () => {
+    const actual = transformer.transform(`
+      /** @jsx jsx */
+      import { jsx } from '${pkg.name}';
+
+      const getFoo = () => 'foobar';
+
+      <div css={{}} className={getFoo()}>hello world</div>
+    `);
+
+    expect(actual).toInclude('className={"test-class" + " " + getFoo()}');
+  });
 
   it.todo('should concat use of inline styles when there is use of dynamic css');
 

--- a/src/ts-transformer/utils/ast-node.tsx
+++ b/src/ts-transformer/utils/ast-node.tsx
@@ -39,6 +39,17 @@ export const getJsxNodeAttributes = (
   return node.openingElement.attributes;
 };
 
+export const getJsxNodeAttributesValue = (
+  node: ts.JsxElement | ts.JsxSelfClosingElement,
+  propertyName: string
+) => {
+  const attribute = getJsxNodeAttributes(node).properties.find(
+    prop => ts.isJsxAttribute(prop) && prop.name.escapedText === propertyName
+  ) as ts.JsxAttribute | undefined;
+
+  return attribute?.initializer ? attribute.initializer : undefined;
+};
+
 export const isPackageModuleImport = (statement: ts.Node, namedImport: string): boolean => {
   if (
     !ts.isImportDeclaration(statement) ||

--- a/src/ts-transformer/utils/expression-operators.tsx
+++ b/src/ts-transformer/utils/expression-operators.tsx
@@ -1,0 +1,20 @@
+import * as ts from 'typescript';
+
+/**
+ * Joins two expressions to a jsx expression, separated by an operator and a space
+ * Example: 'myString' + ' ' + myFunction()
+ */
+export function joinStringLiteralExpression(
+  prepend: ts.Expression,
+  subject: ts.Expression,
+  operator: ts.BinaryOperator | ts.BinaryOperatorToken = ts.SyntaxKind.PlusToken
+) {
+  return ts.createJsxExpression(
+    undefined,
+    ts.createBinary(
+      ts.createBinary(prepend, operator, ts.createStringLiteral(' ')),
+      operator,
+      subject
+    )
+  );
+}


### PR DESCRIPTION
Allows the use of the classname prop 
Classes created from the CSS prop will be interpolated along with the classnames provided by the user. 